### PR TITLE
Advance search and styles and layouts improvements

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     implementation("androidx.navigation:navigation-compose:2.5.3")
     implementation("androidx.security:security-crypto:1.1.0-alpha05")
     implementation("io.coil-kt:coil-compose:2.2.2")
+    implementation("com.google.code.gson:gson:2.10.1")
 
     implementation("com.apollographql.apollo3:apollo-runtime")
 

--- a/app/src/main/graphql/SearchForTerm.graphql
+++ b/app/src/main/graphql/SearchForTerm.graphql
@@ -7,7 +7,16 @@ query SearchForTerm($term: String!, $filterForTypes: [TaddyType]) {
         podcastSeries {
             uuid
             name
-            rssUrl
+            description(shouldStripHtmlTags: true)
+            imageUrl
+            totalEpisodesCount
+            genres
+            language
+            contentType
+            authorName
+            websiteUrl
+            rssOwnerPublicEmail
+            rssOwnerName
         }
     }
 }

--- a/app/src/main/graphql/SearchForTerm.graphql
+++ b/app/src/main/graphql/SearchForTerm.graphql
@@ -1,7 +1,8 @@
-query SearchForTerm($term: String!, $filterForTypes: [TaddyType]) {
+query SearchForTerm($term: String!, $filterForGenres: [Genre], $sortByDatePublished: SortOrder) {
     searchForTerm(
         term: $term
-        filterForTypes: $filterForTypes
+        filterForGenres: $filterForGenres
+        sortByDatePublished: $sortByDatePublished
     ) {
         searchId
         podcastSeries {

--- a/app/src/main/java/com/example/apiproject/CollapsibleAdvancedSearch.kt
+++ b/app/src/main/java/com/example/apiproject/CollapsibleAdvancedSearch.kt
@@ -1,0 +1,2 @@
+package com.example.apiproject
+

--- a/app/src/main/java/com/example/apiproject/MainActivity.kt
+++ b/app/src/main/java/com/example/apiproject/MainActivity.kt
@@ -9,9 +9,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import com.example.apiproject.ui.theme.APIProjectTheme
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -29,20 +31,31 @@ class MainActivity : ComponentActivity() {
 @Composable
 private fun MainNavHost() {
     val navController = rememberNavController()
+
     Column {
-        // Add the AppHeader at the top of the navigation host
         AppHeader(navController = navController)
 
-        // Use the available space below the header for the NavHost
         Box(modifier = Modifier.weight(1f)) {
             NavHost(navController, startDestination = NavigationDestinations.SEARCH_SCREEN) {
                 composable(route = NavigationDestinations.SEARCH_SCREEN) {
-                    SearchScreen(onNavigate = {
-                        navController.navigate(NavigationDestinations.PODCAST_DETAIL)
+                    SearchScreen(onNavigate = { selectedPodcast ->
+                        navController.navigate("${NavigationDestinations.PODCAST_DETAIL}/${selectedPodcast.uuid}")
                     })
                 }
-                composable(route = NavigationDestinations.PODCAST_DETAIL) {
-                    PodcastDetailScreen()
+                composable(
+                    route = NavigationDestinations.PODCAST_DETAIL + "/{podcastUUID}",
+                    arguments = listOf(navArgument("podcastUUID") { type = NavType.StringType })
+                ) { backStackEntry ->
+                    val podcastUUID = backStackEntry.arguments?.getString("podcastUUID")
+                    println("podcastUUID: $podcastUUID")
+
+                    val podcast = SharedPodcastRepository.podcasts?.find { it?.uuid == podcastUUID }
+
+                    println("Retrieved podcast: $podcast")
+
+                    if (podcast != null) {
+                        PodcastDetailScreen(podcast)
+                    }
                 }
                 composable(route = NavigationDestinations.FAVORITES_SCREEN) {
                     FavoritesScreen()

--- a/app/src/main/java/com/example/apiproject/NavigationDestinations.kt
+++ b/app/src/main/java/com/example/apiproject/NavigationDestinations.kt
@@ -2,7 +2,7 @@ package com.example.apiproject
 
 object NavigationDestinations {
     const val SEARCH_SCREEN = "search"
-    const val PODCAST_DETAIL = "podcastDetail"
+    const val PODCAST_DETAIL = "podcast_detail/{podcastUUID}"
     const val FAVORITES_SCREEN = "favorites"
     const val ABOUT_SCREEN = "about"
     const val ACCOUNT_SCREEN = "account"

--- a/app/src/main/java/com/example/apiproject/PodcastDetailScreen.kt
+++ b/app/src/main/java/com/example/apiproject/PodcastDetailScreen.kt
@@ -1,28 +1,95 @@
 package com.example.apiproject
 
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.Image
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.ui.Alignment
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
 import androidx.compose.material3.Text
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
 
 @Composable
-fun PodcastDetailScreen() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Text(
-                text = "Podcast Detail Screen",
-                fontSize = 24.sp,
-                fontWeight = FontWeight.Bold,
-                color = Color.Black,
-                textAlign = TextAlign.Center
-            )
+fun PodcastDetailScreen(podcast: SearchForTermQuery.PodcastSeries) {
+    val context = LocalContext.current
+    val currentPodcast = rememberUpdatedState(podcast)
+
+    fun openWebsite() {
+        val websiteUrl = currentPodcast.value.websiteUrl
+        if (!websiteUrl.isNullOrBlank()) {
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(websiteUrl))
+            context.startActivity(intent)
         }
     }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp)
+    ) {
+        Image(
+            painter = rememberAsyncImagePainter(model = podcast.imageUrl),
+            contentDescription = "Podcast Cover Image",
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(200.dp)
+                .clip(RoundedCornerShape(8.dp))
+        )
+
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = podcast.name ?: "No title found",
+            fontSize = 24.sp,
+            fontWeight = FontWeight.Bold,
+            color = Color.Black,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = podcast.description ?: "No description found",
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Normal,
+            color = Color.Gray,
+            textAlign = TextAlign.Justify
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(text = "Episodes: ${podcast.totalEpisodesCount}")
+        Text(text = "Genre: ${(podcast.genres ?: "NOT_SPECIFIED")}")
+        Text(text = "Language: ${podcast.language}")
+        Text(text = "Content Type: ${podcast.contentType}")
+        Text(text = "Author: ${podcast.authorName}")
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Button(onClick = { openWebsite() }) {
+            Text("Visit Website")
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+    }
 }
+

--- a/app/src/main/java/com/example/apiproject/PodcastList.kt
+++ b/app/src/main/java/com/example/apiproject/PodcastList.kt
@@ -1,0 +1,54 @@
+package com.example.apiproject
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun PodcastList(data: List<SearchForTermQuery.PodcastSeries?>?, onPodcastClick: (SearchForTermQuery.PodcastSeries?) -> Unit) {
+    LazyColumn {
+        items(data.orEmpty()) { podcast ->
+            PodcastListItem(podcast = podcast, onPodcastClick = onPodcastClick)
+        }
+    }
+}
+
+@Composable
+fun PodcastListItem(podcast: SearchForTermQuery.PodcastSeries?, onPodcastClick: (SearchForTermQuery.PodcastSeries?) -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)
+            .clickable {
+                podcast?.let {
+                    onPodcastClick(it)
+                }
+            }
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(16.dp)
+        ) {
+            Text(text = podcast?.name.orEmpty(), style = MaterialTheme.typography.bodyMedium)
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Text(text = "UUID: ${podcast?.uuid}", style = MaterialTheme.typography.bodySmall)
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Text(text = "RSS NAME: ${podcast?.rssOwnerName}", style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the functionality to search for podcasts by term and display the details of the selected podcast. The main changes are:

- Added a new query file `SearchForTerm.graphql` that defines the GraphQL query for searching podcasts by term and filter types.
- Added a new screen `PodcastDetailScreen.kt` that shows the information of the selected podcast, such as name, description, image, episodes, genre, language, etc. It also has a button to open the podcast website in the browser.
- Modified `MainActivity.kt` and `NavigationDestinations.kt` to add the navigation logic for the podcast detail screen. The podcast UUID is passed as an argument to the destination route.
- Modified `SearchScreen.kt` to store the podcasts retrieved from the query in a shared repository object and pass the selected podcast to the navigation function.
- Added a new file `PodcastList.kt` that defines the UI components for displaying the list of podcasts and each podcast item.

Screenshots:

![image](https://github.com/TeamCodeNova/APIProject/assets/53450937/dd22e696-621d-4c45-878c-16eef2e2d371)
![image](https://github.com/TeamCodeNova/APIProject/assets/53450937/cd712d53-43ad-4e78-bb36-3132b86e5a72)
![image](https://github.com/TeamCodeNova/APIProject/assets/53450937/f92ff8b0-df4b-45ff-8fdc-94cc6468e937)
![image](https://github.com/TeamCodeNova/APIProject/assets/53450937/0f57178b-448e-47c5-a01d-30e071967e8e)
![image](https://github.com/TeamCodeNova/APIProject/assets/53450937/f525b181-6fc1-44b3-9b46-8afca5a2de21)

