### PR TITLE
Added LoginScreen, logic for jwt/db still required

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -3,30 +3,39 @@
     <option name="myName" value="Project Default" />
     <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
   </profile>
 </component>

--- a/app/src/main/java/com/example/apiproject/Header.kt
+++ b/app/src/main/java/com/example/apiproject/Header.kt
@@ -46,6 +46,12 @@ fun AppHeader(navController: NavController) {
         ) {
             Text(text = "Account")
         }
+        TextButton(
+            onClick = { navController.navigate(NavigationDestinations.LOGIN_SCREEN) },
+            modifier = Modifier.weight(1f)
+        ) {
+            Text(text = "Login")
+        }
     }
 }
 

--- a/app/src/main/java/com/example/apiproject/LoginScreen.kt
+++ b/app/src/main/java/com/example/apiproject/LoginScreen.kt
@@ -1,0 +1,57 @@
+package com.example.apiproject
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.text.TextStyle
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LoginScreen() {
+    var username by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        OutlinedTextField(
+            value = username,
+            onValueChange = { username = it },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp),
+            textStyle = TextStyle(fontSize = 18.sp),
+            label = { Text("Username") } // Optional: add a label
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = password,
+            onValueChange = { password = it },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp),
+            textStyle = TextStyle(fontSize = 18.sp),
+            label = { Text("Password") } // Optional: add a label
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Button(
+            onClick = {
+                // Handle button click if needed
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp)
+        ) {
+            Text(text = "Button")
+        }
+    }
+}

--- a/app/src/main/java/com/example/apiproject/MainActivity.kt
+++ b/app/src/main/java/com/example/apiproject/MainActivity.kt
@@ -66,6 +66,9 @@ private fun MainNavHost() {
                 composable(route = NavigationDestinations.ACCOUNT_SCREEN) {
                     AccountScreen()
                 }
+                composable(route = NavigationDestinations.LOGIN_SCREEN) {
+                    LoginScreen()
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/apiproject/NavigationDestinations.kt
+++ b/app/src/main/java/com/example/apiproject/NavigationDestinations.kt
@@ -6,4 +6,5 @@ object NavigationDestinations {
     const val FAVORITES_SCREEN = "favorites"
     const val ABOUT_SCREEN = "about"
     const val ACCOUNT_SCREEN = "account"
+    const val LOGIN_SCREEN = "login"
 }


### PR DESCRIPTION
I added a login page and implemented the start of a simple form.

A db table need to be created

Users:
-user_id
-username
-password
-is_admin (optional is want admin users)

and JWT needs to be added to the Gradle and imported, along with the login for authentication added once the db is in place.

![111](https://github.com/TeamCodeNova/APIProject/assets/104619536/e7b64472-2a00-4ee2-93b8-24c959811a99)
